### PR TITLE
Merge dive logic for slice, array and map

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -173,6 +173,25 @@ Here is a list of the current built in validators:
 		such as min or max won't run, but if a value is set validation will run.
 		(Usage: omitempty)
 
+	dive
+		This tells the validator to dive into a slice, array or map and validate that
+		level of the slice, array or map with the validation tags that follow.
+		Multidimensional nesting is also supported, each level you with to dive will
+		require another dive tag. (Usage: dive)
+		Example: [][]string with validation tag "gt=0,dive,len=1,dive,required"
+		gt=0 will be applied to []
+		len=1 will be applied to []string
+		required will be applied to string
+		Example2: [][]string with validation tag "gt=0,dive,dive,required"
+		gt=0 will be applied to []
+		[]string will be spared validation
+		required will be applied to string
+		NOTE: in Example2 if the required validation failed, but all others passed
+		the hierarchy of FieldError's in the middle with have their IsPlaceHolder field
+		set to true. If a FieldError has IsSliceOrMap=true or IsMap=true then the
+		FieldError is a Slice or Map field and if IsPlaceHolder=true then contains errors
+		within its SliceOrArrayErrs or MapErrs fields.
+
 	required
 		This validates that the value is not the data types default value.
 		For numbers ensures value is not zero. For strings ensures value is

--- a/validator.go
+++ b/validator.go
@@ -209,21 +209,14 @@ func (e *StructErrors) Error() string {
 
 	for _, err := range e.Errors {
 		buff.WriteString(err.Error())
+		buff.WriteString("\n")
 	}
-
-	var i uint64
 
 	for _, err := range e.StructErrors {
-
-		if i != 0 {
-			buff.WriteString("\n")
-		}
-
 		buff.WriteString(err.Error())
-		i++
 	}
 
-	return buff.String()
+	return strings.TrimSpace(buff.String())
 }
 
 // Flatten flattens the StructErrors hierarchical structure into a flat namespace style field name

--- a/validator.go
+++ b/validator.go
@@ -697,8 +697,6 @@ func (v *Validate) traverseMap(val interface{}, current interface{}, valueField 
 			cField.mapSubKind = idxField.Kind()
 		}
 
-		// fmt.Println(cField.sliceSubKind)
-
 		switch cField.mapSubKind {
 		case reflect.Struct, reflect.Interface:
 
@@ -720,7 +718,7 @@ func (v *Validate) traverseMap(val interface{}, current interface{}, valueField 
 				if strings.Contains(cField.tag, required) {
 
 					errs[key.Interface()] = &FieldError{
-						Field: cField.name,
+						Field: fmt.Sprintf(mapIndexFieldName, cField.name, key.Interface()),
 						Tag:   required,
 						Value: idxField.Interface(),
 						Kind:  reflect.Ptr,
@@ -779,7 +777,7 @@ func (v *Validate) traverseSliceOrArray(val interface{}, current interface{}, va
 				if strings.Contains(cField.tag, required) {
 
 					errs[i] = &FieldError{
-						Field: cField.name,
+						Field: fmt.Sprintf(arrayIndexFieldName, cField.name, i),
 						Tag:   required,
 						Value: idxField.Interface(),
 						Kind:  reflect.Ptr,

--- a/validator.go
+++ b/validator.go
@@ -173,27 +173,14 @@ func (e *FieldError) Error() string {
 
 		if e.IsSliceOrArray {
 
-			for i, err := range e.SliceOrArrayErrs {
-
-				if i != 0 {
-					buff.WriteString("\n")
-				}
-
-				buff.WriteString(fmt.Sprintf(sliceErrMsg, e.Field, i, err))
+			for j, err := range e.SliceOrArrayErrs {
+				buff.WriteString(fmt.Sprintf(sliceErrMsg, e.Field, j, "\n"+err.Error()))
 			}
 
 		} else if e.IsMap {
 
-			var i uint64
-
 			for key, err := range e.MapErrs {
-
-				if i != 0 {
-					buff.WriteString("\n")
-				}
-
-				buff.WriteString(fmt.Sprintf(mapErrMsg, e.Field, key, err))
-				i++
+				buff.WriteString(fmt.Sprintf(mapErrMsg, e.Field, key, "\n"+err.Error()))
 			}
 		}
 
@@ -233,7 +220,6 @@ func (e *StructErrors) Error() string {
 		}
 
 		buff.WriteString(err.Error())
-
 		i++
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -231,49 +231,49 @@ func TestMapDiveValidation(t *testing.T) {
 
 func TestArrayDiveValidation(t *testing.T) {
 
-	// type Test struct {
-	// 	Errs []string `validate:"gt=0,dive,required"`
-	// }
+	type Test struct {
+		Errs []string `validate:"gt=0,dive,required"`
+	}
 
-	// test := &Test{
-	// 	Errs: []string{"ok", "", "ok"},
-	// }
+	test := &Test{
+		Errs: []string{"ok", "", "ok"},
+	}
 
-	// errs := validate.Struct(test)
-	// NotEqual(t, errs, nil)
-	// Equal(t, len(errs.Errors), 1)
+	errs := validate.Struct(test)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
 
-	// fieldErr, ok := errs.Errors["Errs"]
-	// Equal(t, ok, true)
-	// Equal(t, fieldErr.IsPlaceholderErr, true)
-	// Equal(t, fieldErr.IsSliceOrArray, true)
-	// Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
+	fieldErr, ok := errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
 
-	// innerErr, ok := fieldErr.SliceOrArrayErrs[1].(*FieldError)
-	// Equal(t, ok, true)
-	// Equal(t, innerErr.Tag, required)
-	// Equal(t, innerErr.IsPlaceholderErr, false)
-	// Equal(t, innerErr.Field, "Errs")
+	innerErr, ok := fieldErr.SliceOrArrayErrs[1].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, innerErr.Tag, required)
+	Equal(t, innerErr.IsPlaceholderErr, false)
+	Equal(t, innerErr.Field, "Errs[1]")
 
-	// test = &Test{
-	// 	Errs: []string{"ok", "ok", ""},
-	// }
+	test = &Test{
+		Errs: []string{"ok", "ok", ""},
+	}
 
-	// errs = validate.Struct(test)
-	// NotEqual(t, errs, nil)
-	// Equal(t, len(errs.Errors), 1)
+	errs = validate.Struct(test)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
 
-	// fieldErr, ok = errs.Errors["Errs"]
-	// Equal(t, ok, true)
-	// Equal(t, fieldErr.IsPlaceholderErr, true)
-	// Equal(t, fieldErr.IsSliceOrArray, true)
-	// Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
+	fieldErr, ok = errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
 
-	// innerErr, ok = fieldErr.SliceOrArrayErrs[2].(*FieldError)
-	// Equal(t, ok, true)
-	// Equal(t, innerErr.Tag, required)
-	// Equal(t, innerErr.IsPlaceholderErr, false)
-	// Equal(t, innerErr.Field, "Errs")
+	innerErr, ok = fieldErr.SliceOrArrayErrs[2].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, innerErr.Tag, required)
+	Equal(t, innerErr.IsPlaceholderErr, false)
+	Equal(t, innerErr.Field, "Errs[2]")
 
 	type TestMultiDimensional struct {
 		Errs [][]string `validate:"gt=0,dive,dive,required"`
@@ -283,25 +283,17 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errArray = append(errArray, []string{"ok", "", ""})
 	errArray = append(errArray, []string{"ok", "", ""})
-	// fmt.Println(len(errArray))
-	// errArray = append(errArray, []string{"", "ok", "ok"})
-	// errArray = append(errArray, []string{"", "", "ok"})
-	// errArray = append(errArray, []string{"", "", "ok"})
 
 	tm := &TestMultiDimensional{
 		Errs: errArray,
 	}
 
-	errs := validate.Struct(tm)
-	fmt.Println(errs)
-	// validate.Struct(tm)
-
-	// fmt.Printf("%#v\n", errs.Errors["Errs"].SliceOrArrayErrs)
+	errs = validate.Struct(tm)
 
 	NotEqual(t, errs, nil)
 	Equal(t, len(errs.Errors), 1)
 
-	fieldErr, ok := errs.Errors["Errs"]
+	fieldErr, ok = errs.Errors["Errs"]
 	Equal(t, ok, true)
 	Equal(t, fieldErr.IsPlaceholderErr, true)
 	Equal(t, fieldErr.IsSliceOrArray, true)
@@ -319,14 +311,6 @@ func TestArrayDiveValidation(t *testing.T) {
 	Equal(t, innerSliceError1.Tag, required)
 	Equal(t, innerSliceError1.IsSliceOrArray, false)
 	Equal(t, len(innerSliceError1.SliceOrArrayErrs), 0)
-	// fmt.Println(fieldErr.SliceOrArrayErrs)
-
-	// Equal(t, fieldErr.IsPlaceholderErr, true)
-	// Equal(t, fieldErr.IsSliceOrArray, true)
-	// Equal(t, len(fieldErr.SliceOrArrayErrs), 3)
-
-	// fmt.Println(fieldErr.SliceOrArrayErrs)
-	// fmt.Println(len(fieldErr.SliceOrArrayErrs))
 }
 
 func TestNilStructPointerValidation(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -237,8 +237,42 @@ func TestArrayDiveValidation(t *testing.T) {
 	}
 
 	errs := validate.Struct(test)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
 
-	fmt.Println(errs)
+	fieldErr, ok := errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
+
+	innerErr, ok := fieldErr.SliceOrArrayErrs[1].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, innerErr.Tag, required)
+	Equal(t, innerErr.IsPlaceholderErr, false)
+	Equal(t, innerErr.Field, "Errs")
+
+	test = &Test{
+		Errs: []string{"ok", "ok", ""},
+	}
+
+	errs = validate.Struct(test)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
+
+	fieldErr, ok = errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
+
+	innerErr, ok = fieldErr.SliceOrArrayErrs[2].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, innerErr.Tag, required)
+	Equal(t, innerErr.IsPlaceholderErr, false)
+	Equal(t, innerErr.Field, "Errs")
+
+	fmt.Println(errs.Errors["Errs"].IsPlaceholderErr)
 
 	// type TestMap struct {
 	// 	Errs *map[int]string `validate:"gt=0,dive,required"`

--- a/validator_test.go
+++ b/validator_test.go
@@ -361,6 +361,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errStructPtrArray = append(errStructPtrArray, []*Inner{&Inner{"ok"}, &Inner{""}, &Inner{""}})
 	errStructPtrArray = append(errStructPtrArray, []*Inner{&Inner{"ok"}, &Inner{""}, &Inner{""}})
+	errStructPtrArray = append(errStructPtrArray, []*Inner{&Inner{"ok"}, &Inner{""}, nil})
 
 	tmsp := &TestMultiDimensionalStructsPtr{
 		Errs: errStructPtrArray,
@@ -374,7 +375,7 @@ func TestArrayDiveValidation(t *testing.T) {
 	Equal(t, ok, true)
 	Equal(t, fieldErr.IsPlaceholderErr, true)
 	Equal(t, fieldErr.IsSliceOrArray, true)
-	Equal(t, len(fieldErr.SliceOrArrayErrs), 2)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 3)
 
 	sliceError1, ok = fieldErr.SliceOrArrayErrs[0].(*FieldError)
 	Equal(t, ok, true)
@@ -390,6 +391,168 @@ func TestArrayDiveValidation(t *testing.T) {
 	Equal(t, innerInnersliceError1.IsPlaceholderErr, false)
 	Equal(t, innerInnersliceError1.IsSliceOrArray, false)
 	Equal(t, len(innerInnersliceError1.SliceOrArrayErrs), 0)
+
+	type TestMultiDimensionalStructsPtr2 struct {
+		Errs [][]*Inner `validate:"gt=0,dive,dive,required"`
+	}
+
+	var errStructPtr2Array [][]*Inner
+
+	errStructPtr2Array = append(errStructPtr2Array, []*Inner{&Inner{"ok"}, &Inner{""}, &Inner{""}})
+	errStructPtr2Array = append(errStructPtr2Array, []*Inner{&Inner{"ok"}, &Inner{""}, &Inner{""}})
+	errStructPtr2Array = append(errStructPtr2Array, []*Inner{&Inner{"ok"}, &Inner{""}, nil})
+
+	tmsp2 := &TestMultiDimensionalStructsPtr2{
+		Errs: errStructPtr2Array,
+	}
+
+	errs = validate.Struct(tmsp2)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
+
+	fieldErr, ok = errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 3)
+
+	sliceError1, ok = fieldErr.SliceOrArrayErrs[0].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, sliceError1.IsPlaceholderErr, true)
+	Equal(t, sliceError1.IsSliceOrArray, true)
+	Equal(t, len(sliceError1.SliceOrArrayErrs), 2)
+
+	innerSliceStructError1, ok = sliceError1.SliceOrArrayErrs[1].(*StructErrors)
+	Equal(t, ok, true)
+	Equal(t, len(innerSliceStructError1.Errors), 1)
+
+	innerInnersliceError1 = innerSliceStructError1.Errors["Name"]
+	Equal(t, innerInnersliceError1.IsPlaceholderErr, false)
+	Equal(t, innerInnersliceError1.IsSliceOrArray, false)
+	Equal(t, len(innerInnersliceError1.SliceOrArrayErrs), 0)
+
+	type TestMultiDimensionalStructsPtr3 struct {
+		Errs [][]*Inner `validate:"gt=0,dive,dive,omitempty"`
+	}
+
+	var errStructPtr3Array [][]*Inner
+
+	errStructPtr3Array = append(errStructPtr3Array, []*Inner{&Inner{"ok"}, &Inner{""}, &Inner{""}})
+	errStructPtr3Array = append(errStructPtr3Array, []*Inner{&Inner{"ok"}, &Inner{""}, &Inner{""}})
+	errStructPtr3Array = append(errStructPtr3Array, []*Inner{&Inner{"ok"}, &Inner{""}, nil})
+
+	tmsp3 := &TestMultiDimensionalStructsPtr3{
+		Errs: errStructPtr3Array,
+	}
+
+	errs = validate.Struct(tmsp3)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
+
+	fieldErr, ok = errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 3)
+
+	sliceError1, ok = fieldErr.SliceOrArrayErrs[0].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, sliceError1.IsPlaceholderErr, true)
+	Equal(t, sliceError1.IsSliceOrArray, true)
+	Equal(t, len(sliceError1.SliceOrArrayErrs), 2)
+
+	innerSliceStructError1, ok = sliceError1.SliceOrArrayErrs[1].(*StructErrors)
+	Equal(t, ok, true)
+	Equal(t, len(innerSliceStructError1.Errors), 1)
+
+	innerInnersliceError1 = innerSliceStructError1.Errors["Name"]
+	Equal(t, innerInnersliceError1.IsPlaceholderErr, false)
+	Equal(t, innerInnersliceError1.IsSliceOrArray, false)
+	Equal(t, len(innerInnersliceError1.SliceOrArrayErrs), 0)
+
+	type TestMultiDimensionalTimeTime struct {
+		Errs [][]*time.Time `validate:"gt=0,dive,dive,required"`
+	}
+
+	var errTimePtr3Array [][]*time.Time
+
+	t1 := time.Now().UTC()
+	t2 := time.Now().UTC()
+	t3 := time.Now().UTC().Add(time.Hour * 24)
+
+	errTimePtr3Array = append(errTimePtr3Array, []*time.Time{&t1, &t2, &t3})
+	errTimePtr3Array = append(errTimePtr3Array, []*time.Time{&t1, &t2, nil})
+	errTimePtr3Array = append(errTimePtr3Array, []*time.Time{&t1, nil, nil})
+
+	tmtp3 := &TestMultiDimensionalTimeTime{
+		Errs: errTimePtr3Array,
+	}
+
+	errs = validate.Struct(tmtp3)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
+
+	fieldErr, ok = errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 2)
+
+	sliceError1, ok = fieldErr.SliceOrArrayErrs[2].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, sliceError1.IsPlaceholderErr, true)
+	Equal(t, sliceError1.IsSliceOrArray, true)
+	Equal(t, len(sliceError1.SliceOrArrayErrs), 2)
+
+	innerSliceError1, ok = sliceError1.SliceOrArrayErrs[1].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, innerSliceError1.IsPlaceholderErr, false)
+	Equal(t, innerSliceError1.IsSliceOrArray, false)
+	Equal(t, len(innerSliceError1.SliceOrArrayErrs), 0)
+	Equal(t, innerSliceError1.Field, "Errs[2]")
+	Equal(t, innerSliceError1.Tag, required)
+
+	type TestMultiDimensionalTimeTime2 struct {
+		Errs [][]*time.Time `validate:"gt=0,dive,dive,required"`
+	}
+
+	var errTimeArray [][]*time.Time
+
+	t1 = time.Now().UTC()
+	t2 = time.Now().UTC()
+	t3 = time.Now().UTC().Add(time.Hour * 24)
+
+	errTimeArray = append(errTimeArray, []*time.Time{&t1, &t2, &t3})
+	errTimeArray = append(errTimeArray, []*time.Time{&t1, &t2, nil})
+	errTimeArray = append(errTimeArray, []*time.Time{&t1, nil, nil})
+
+	tmtp := &TestMultiDimensionalTimeTime2{
+		Errs: errTimeArray,
+	}
+
+	errs = validate.Struct(tmtp)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
+
+	fieldErr, ok = errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 2)
+
+	sliceError1, ok = fieldErr.SliceOrArrayErrs[2].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, sliceError1.IsPlaceholderErr, true)
+	Equal(t, sliceError1.IsSliceOrArray, true)
+	Equal(t, len(sliceError1.SliceOrArrayErrs), 2)
+
+	innerSliceError1, ok = sliceError1.SliceOrArrayErrs[1].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, innerSliceError1.IsPlaceholderErr, false)
+	Equal(t, innerSliceError1.IsSliceOrArray, false)
+	Equal(t, len(innerSliceError1.SliceOrArrayErrs), 0)
+	Equal(t, innerSliceError1.Field, "Errs[2]")
+	Equal(t, innerSliceError1.Tag, required)
 }
 
 func TestNilStructPointerValidation(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -226,17 +226,78 @@ func AssertMapFieldError(t *testing.T, s map[string]*FieldError, field string, e
 	EqualSkip(t, 2, val.Tag, expectedTag)
 }
 
+func TestMapDiveValidation(t *testing.T) {
+}
+
 func TestArrayDiveValidation(t *testing.T) {
 
-	type Test struct {
-		Errs []string `validate:"gt=0,dive,required"`
+	// type Test struct {
+	// 	Errs []string `validate:"gt=0,dive,required"`
+	// }
+
+	// test := &Test{
+	// 	Errs: []string{"ok", "", "ok"},
+	// }
+
+	// errs := validate.Struct(test)
+	// NotEqual(t, errs, nil)
+	// Equal(t, len(errs.Errors), 1)
+
+	// fieldErr, ok := errs.Errors["Errs"]
+	// Equal(t, ok, true)
+	// Equal(t, fieldErr.IsPlaceholderErr, true)
+	// Equal(t, fieldErr.IsSliceOrArray, true)
+	// Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
+
+	// innerErr, ok := fieldErr.SliceOrArrayErrs[1].(*FieldError)
+	// Equal(t, ok, true)
+	// Equal(t, innerErr.Tag, required)
+	// Equal(t, innerErr.IsPlaceholderErr, false)
+	// Equal(t, innerErr.Field, "Errs")
+
+	// test = &Test{
+	// 	Errs: []string{"ok", "ok", ""},
+	// }
+
+	// errs = validate.Struct(test)
+	// NotEqual(t, errs, nil)
+	// Equal(t, len(errs.Errors), 1)
+
+	// fieldErr, ok = errs.Errors["Errs"]
+	// Equal(t, ok, true)
+	// Equal(t, fieldErr.IsPlaceholderErr, true)
+	// Equal(t, fieldErr.IsSliceOrArray, true)
+	// Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
+
+	// innerErr, ok = fieldErr.SliceOrArrayErrs[2].(*FieldError)
+	// Equal(t, ok, true)
+	// Equal(t, innerErr.Tag, required)
+	// Equal(t, innerErr.IsPlaceholderErr, false)
+	// Equal(t, innerErr.Field, "Errs")
+
+	type TestMultiDimensional struct {
+		Errs [][]string `validate:"gt=0,dive,dive,required"`
 	}
 
-	test := &Test{
-		Errs: []string{"ok", "", "ok"},
+	var errArray [][]string
+
+	errArray = append(errArray, []string{"ok", "", ""})
+	errArray = append(errArray, []string{"ok", "", ""})
+	// fmt.Println(len(errArray))
+	// errArray = append(errArray, []string{"", "ok", "ok"})
+	// errArray = append(errArray, []string{"", "", "ok"})
+	// errArray = append(errArray, []string{"", "", "ok"})
+
+	tm := &TestMultiDimensional{
+		Errs: errArray,
 	}
 
-	errs := validate.Struct(test)
+	errs := validate.Struct(tm)
+	fmt.Println(errs)
+	// validate.Struct(tm)
+
+	// fmt.Printf("%#v\n", errs.Errors["Errs"].SliceOrArrayErrs)
+
 	NotEqual(t, errs, nil)
 	Equal(t, len(errs.Errors), 1)
 
@@ -244,52 +305,28 @@ func TestArrayDiveValidation(t *testing.T) {
 	Equal(t, ok, true)
 	Equal(t, fieldErr.IsPlaceholderErr, true)
 	Equal(t, fieldErr.IsSliceOrArray, true)
-	Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 2)
 
-	innerErr, ok := fieldErr.SliceOrArrayErrs[1].(*FieldError)
+	sliceError1, ok := fieldErr.SliceOrArrayErrs[0].(*FieldError)
 	Equal(t, ok, true)
-	Equal(t, innerErr.Tag, required)
-	Equal(t, innerErr.IsPlaceholderErr, false)
-	Equal(t, innerErr.Field, "Errs")
+	Equal(t, sliceError1.IsPlaceholderErr, true)
+	Equal(t, sliceError1.IsSliceOrArray, true)
+	Equal(t, len(sliceError1.SliceOrArrayErrs), 2)
 
-	test = &Test{
-		Errs: []string{"ok", "ok", ""},
-	}
-
-	errs = validate.Struct(test)
-	NotEqual(t, errs, nil)
-	Equal(t, len(errs.Errors), 1)
-
-	fieldErr, ok = errs.Errors["Errs"]
+	innerSliceError1, ok := sliceError1.SliceOrArrayErrs[1].(*FieldError)
 	Equal(t, ok, true)
-	Equal(t, fieldErr.IsPlaceholderErr, true)
-	Equal(t, fieldErr.IsSliceOrArray, true)
-	Equal(t, len(fieldErr.SliceOrArrayErrs), 1)
+	Equal(t, innerSliceError1.IsPlaceholderErr, false)
+	Equal(t, innerSliceError1.Tag, required)
+	Equal(t, innerSliceError1.IsSliceOrArray, false)
+	Equal(t, len(innerSliceError1.SliceOrArrayErrs), 0)
+	// fmt.Println(fieldErr.SliceOrArrayErrs)
 
-	innerErr, ok = fieldErr.SliceOrArrayErrs[2].(*FieldError)
-	Equal(t, ok, true)
-	Equal(t, innerErr.Tag, required)
-	Equal(t, innerErr.IsPlaceholderErr, false)
-	Equal(t, innerErr.Field, "Errs")
+	// Equal(t, fieldErr.IsPlaceholderErr, true)
+	// Equal(t, fieldErr.IsSliceOrArray, true)
+	// Equal(t, len(fieldErr.SliceOrArrayErrs), 3)
 
-	fmt.Println(errs.Errors["Errs"].IsPlaceholderErr)
-
-	// type TestMap struct {
-	// 	Errs *map[int]string `validate:"gt=0,dive,required"`
-	// }
-
-	// m := map[int]string{}
-	// m[1] = "ok"
-	// m[2] = ""
-	// m[3] = "ok"
-
-	// testMap := &TestMap{
-	// 	Errs: &m,
-	// }
-
-	// errs = validate.Struct(testMap)
-
-	// fmt.Println(errs)
+	// fmt.Println(fieldErr.SliceOrArrayErrs)
+	// fmt.Println(len(fieldErr.SliceOrArrayErrs))
 }
 
 func TestNilStructPointerValidation(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -289,7 +289,6 @@ func TestArrayDiveValidation(t *testing.T) {
 	}
 
 	errs = validate.Struct(tm)
-
 	NotEqual(t, errs, nil)
 	Equal(t, len(errs.Errors), 1)
 
@@ -311,6 +310,86 @@ func TestArrayDiveValidation(t *testing.T) {
 	Equal(t, innerSliceError1.Tag, required)
 	Equal(t, innerSliceError1.IsSliceOrArray, false)
 	Equal(t, len(innerSliceError1.SliceOrArrayErrs), 0)
+
+	type Inner struct {
+		Name string `validate:"required"`
+	}
+
+	type TestMultiDimensionalStructs struct {
+		Errs [][]Inner `validate:"gt=0,dive,dive"`
+	}
+
+	var errStructArray [][]Inner
+
+	errStructArray = append(errStructArray, []Inner{Inner{"ok"}, Inner{""}, Inner{""}})
+	errStructArray = append(errStructArray, []Inner{Inner{"ok"}, Inner{""}, Inner{""}})
+
+	tms := &TestMultiDimensionalStructs{
+		Errs: errStructArray,
+	}
+
+	errs = validate.Struct(tms)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
+
+	fieldErr, ok = errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 2)
+
+	sliceError1, ok = fieldErr.SliceOrArrayErrs[0].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, sliceError1.IsPlaceholderErr, true)
+	Equal(t, sliceError1.IsSliceOrArray, true)
+	Equal(t, len(sliceError1.SliceOrArrayErrs), 2)
+
+	innerSliceStructError1, ok := sliceError1.SliceOrArrayErrs[1].(*StructErrors)
+	Equal(t, ok, true)
+	Equal(t, len(innerSliceStructError1.Errors), 1)
+
+	innerInnersliceError1 := innerSliceStructError1.Errors["Name"]
+	Equal(t, innerInnersliceError1.IsPlaceholderErr, false)
+	Equal(t, innerInnersliceError1.IsSliceOrArray, false)
+	Equal(t, len(innerInnersliceError1.SliceOrArrayErrs), 0)
+
+	type TestMultiDimensionalStructsPtr struct {
+		Errs [][]*Inner `validate:"gt=0,dive,dive"`
+	}
+
+	var errStructPtrArray [][]*Inner
+
+	errStructPtrArray = append(errStructPtrArray, []*Inner{&Inner{"ok"}, &Inner{""}, &Inner{""}})
+	errStructPtrArray = append(errStructPtrArray, []*Inner{&Inner{"ok"}, &Inner{""}, &Inner{""}})
+
+	tmsp := &TestMultiDimensionalStructsPtr{
+		Errs: errStructPtrArray,
+	}
+
+	errs = validate.Struct(tmsp)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.Errors), 1)
+
+	fieldErr, ok = errs.Errors["Errs"]
+	Equal(t, ok, true)
+	Equal(t, fieldErr.IsPlaceholderErr, true)
+	Equal(t, fieldErr.IsSliceOrArray, true)
+	Equal(t, len(fieldErr.SliceOrArrayErrs), 2)
+
+	sliceError1, ok = fieldErr.SliceOrArrayErrs[0].(*FieldError)
+	Equal(t, ok, true)
+	Equal(t, sliceError1.IsPlaceholderErr, true)
+	Equal(t, sliceError1.IsSliceOrArray, true)
+	Equal(t, len(sliceError1.SliceOrArrayErrs), 2)
+
+	innerSliceStructError1, ok = sliceError1.SliceOrArrayErrs[1].(*StructErrors)
+	Equal(t, ok, true)
+	Equal(t, len(innerSliceStructError1.Errors), 1)
+
+	innerInnersliceError1 = innerSliceStructError1.Errors["Name"]
+	Equal(t, innerInnersliceError1.IsPlaceholderErr, false)
+	Equal(t, innerInnersliceError1.IsSliceOrArray, false)
+	Equal(t, len(innerInnersliceError1.SliceOrArrayErrs), 0)
 }
 
 func TestNilStructPointerValidation(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -226,6 +226,38 @@ func AssertMapFieldError(t *testing.T, s map[string]*FieldError, field string, e
 	EqualSkip(t, 2, val.Tag, expectedTag)
 }
 
+func TestArrayDiveValidation(t *testing.T) {
+
+	type Test struct {
+		Errs []string `validate:"gt=0,dive,required"`
+	}
+
+	test := &Test{
+		Errs: []string{"ok", "", "ok"},
+	}
+
+	errs := validate.Struct(test)
+
+	fmt.Println(errs)
+
+	// type TestMap struct {
+	// 	Errs *map[int]string `validate:"gt=0,dive,required"`
+	// }
+
+	// m := map[int]string{}
+	// m[1] = "ok"
+	// m[2] = ""
+	// m[3] = "ok"
+
+	// testMap := &TestMap{
+	// 	Errs: &m,
+	// }
+
+	// errs = validate.Struct(testMap)
+
+	// fmt.Println(errs)
+}
+
 func TestNilStructPointerValidation(t *testing.T) {
 	type Inner struct {
 		Data string

--- a/validator_test.go
+++ b/validator_test.go
@@ -227,6 +227,18 @@ func AssertMapFieldError(t *testing.T, s map[string]*FieldError, field string, e
 }
 
 func TestMapDiveValidation(t *testing.T) {
+
+	type Test struct {
+		Errs map[int]string `validate:"gt=0,dive,required"`
+	}
+
+	test := &Test{
+		Errs: map[int]string{0: "ok", 1: "", 4: "ok"},
+	}
+
+	errs := validate.Struct(test)
+
+	fmt.Println(errs)
 }
 
 func TestArrayDiveValidation(t *testing.T) {
@@ -509,7 +521,7 @@ func TestArrayDiveValidation(t *testing.T) {
 	Equal(t, innerSliceError1.IsPlaceholderErr, false)
 	Equal(t, innerSliceError1.IsSliceOrArray, false)
 	Equal(t, len(innerSliceError1.SliceOrArrayErrs), 0)
-	Equal(t, innerSliceError1.Field, "Errs[2]")
+	Equal(t, innerSliceError1.Field, "Errs[2][1]")
 	Equal(t, innerSliceError1.Tag, required)
 
 	type TestMultiDimensionalTimeTime2 struct {
@@ -551,7 +563,7 @@ func TestArrayDiveValidation(t *testing.T) {
 	Equal(t, innerSliceError1.IsPlaceholderErr, false)
 	Equal(t, innerSliceError1.IsSliceOrArray, false)
 	Equal(t, len(innerSliceError1.SliceOrArrayErrs), 0)
-	Equal(t, innerSliceError1.Field, "Errs[2]")
+	Equal(t, innerSliceError1.Field, "Errs[2][1]")
 	Equal(t, innerSliceError1.Tag, required)
 }
 


### PR DESCRIPTION
benchmarks have slightly increased b/ops for this functionality
```go
$ go test -cpu=4 -bench=. -benchmem=true
PASS
BenchmarkValidateField-4	 		 3000000	       439 ns/op	     192 B/op	       2 allocs/op
BenchmarkValidateStructSimple-4	 	 1000000	      2382 ns/op	     656 B/op	      10 allocs/op
BenchmarkTemplateParallelSimple-4	 2000000	       910 ns/op	     656 B/op	      10 allocs/op
BenchmarkValidateStructLarge-4	  	  100000	     13201 ns/op	    4309 B/op	      60 allocs/op
BenchmarkTemplateParallelLarge-4	  300000	      5240 ns/op	    4311 B/op	      60 allocs/op
```

for #78 