### PR TITLE
V5 development

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -546,7 +546,7 @@ func hasLengthOf(top interface{}, current interface{}, field interface{}, param 
 	case reflect.String:
 		p := asInt(param)
 
-		return int64(len(st.String())) == p
+		return int64(len([]rune(st.String()))) == p
 
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p := asInt(param)


### PR DESCRIPTION
when validating length of a web string, we care about its character length but not its byte length. Such as the character length of "你好a" is 3 which we demand, but not its byte length 2*3+1 which makes confusion.