### PR TITLE
Update examples_test.go

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -3,7 +3,7 @@ package validator_test
 import (
 	"fmt"
 
-	"../validator"
+	"gopkg.in/bluesuncorp/validator.v6"
 )
 
 func ExampleValidate_new() {


### PR DESCRIPTION
Please don't use relative paths. I want to use the package but this is causing problems. I plan on using the package during my GolangUK talk on Friday but I need this fixed.