### PR TITLE
Update examples_test.go

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -3,7 +3,7 @@ package validator_test
 import (
 	"fmt"
 
-	"../validator"
+	"gopkg.in/bluesuncorp/validator.v6"
 )
 
 func ExampleValidate_new() {


### PR DESCRIPTION
This is better. We can't use relative paths for imports. If you can get this change in, it will help with my talk at GolangUK on Friday.