### PR TITLE
New v8 Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ Installation
 
 Use go get.
 
-	go get gopkg.in/bluesuncorp/validator.v7
+	go get gopkg.in/bluesuncorp/validator.v8
 
 or to update
 
-	go get -u gopkg.in/bluesuncorp/validator.v7
+	go get -u gopkg.in/bluesuncorp/validator.v8
 
 Then import the validator package into your own code.
 
-	import "gopkg.in/bluesuncorp/validator.v7"
+	import "gopkg.in/bluesuncorp/validator.v8"
 
 Usage and documentation
 ------
 
-Please see http://godoc.org/gopkg.in/bluesuncorp/validator.v7 for detailed usage docs.
+Please see http://godoc.org/gopkg.in/bluesuncorp/validator.v8 for detailed usage docs.
 
 ##### Examples:
 
@@ -45,7 +45,7 @@ package main
 import (
 	"fmt"
 
-	"gopkg.in/bluesuncorp/validator.v7"
+	"gopkg.in/bluesuncorp/validator.v8"
 )
 
 // User contains user information
@@ -70,10 +70,7 @@ var validate *validator.Validate
 
 func main() {
 
-	config := validator.Config{
-		TagName:         "validate",
-		ValidationFuncs: validator.BakedInValidators,
-	}
+	config := &validator.Config{TagName: "validate"}
 
 	validate = validator.New(config)
 
@@ -99,13 +96,13 @@ func validateStruct() {
 	}
 
 	// returns nil or ValidationErrors ( map[string]*FieldError )
-	errs := validate.Struct(user)
+	err := validate.Struct(user)
 
 	if errs != nil {
 
 		fmt.Println(errs) // output: Key: "User.Age" Error:Field validation for "Age" failed on the "lte" tag
 		//	                         Key: "User.Addresses[0].City" Error:Field validation for "City" failed on the "required" tag
-		err := errs["User.Addresses[0].City"]
+		err := errs.(validator.ValidationErrors)["User.Addresses[0].City"]
 		fmt.Println(err.Field) // output: City
 		fmt.Println(err.Tag)   // output: required
 		fmt.Println(err.Kind)  // output: string
@@ -144,7 +141,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"gopkg.in/bluesuncorp/validator.v7"
+	"gopkg.in/bluesuncorp/validator.v8"
 )
 
 // DbBackedUser User struct
@@ -155,10 +152,7 @@ type DbBackedUser struct {
 
 func main() {
 
-	config := validator.Config{
-		TagName:         "validate",
-		ValidationFuncs: validator.BakedInValidators,
-	}
+	config := &validator.Config{TagName: "validate"}
 
 	validate := validator.New(config)
 
@@ -168,7 +162,7 @@ func main() {
 	x := DbBackedUser{Name: sql.NullString{String: "", Valid: true}, Age: sql.NullInt64{Int64: 0, Valid: false}}
 	errs := validate.Struct(x)
 
-	if len(errs) > 0 {
+	if len(errs.(validator.ValidationErrors)) > 0 {
 		fmt.Printf("Errs:\n%+v\n", errs)
 	}
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It has the following **unique** features:
 -   Slice, Array and Map diving, which allows any or all levels of a multidimensional field to be validated.  
 -   Handles type interface by determining it's underlying type prior to validation.
 -   Handles custom field types such as sql driver Valuer see [Valuer](https://golang.org/src/database/sql/driver/types.go?s=1210:1293#L29)
+-   Alias validation tags, which allows for mapping of several validations to a single tag for easier defining of validations on structs
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -205,32 +205,32 @@ Benchmarks
 ```go
 $ go test -cpu=4 -bench=. -benchmem=true
 PASS
-BenchmarkFieldSuccess-4                            	 5000000	       292 ns/op	      16 B/op	       1 allocs/op
-BenchmarkFieldFailure-4                            	 5000000	       291 ns/op	      16 B/op	       1 allocs/op
-BenchmarkFieldDiveSuccess-4                        	  500000	      2518 ns/op	     384 B/op	      19 allocs/op
-BenchmarkFieldDiveFailure-4                        	  500000	      3059 ns/op	     768 B/op	      23 allocs/op
-BenchmarkFieldCustomTypeSuccess-4                  	 3000000	       444 ns/op	      32 B/op	       2 allocs/op
-BenchmarkFieldCustomTypeFailure-4                  	 2000000	       766 ns/op	     384 B/op	       4 allocs/op
-BenchmarkFieldOrTagSuccess-4                       	 1000000	      1344 ns/op	      32 B/op	       2 allocs/op
-BenchmarkFieldOrTagFailure-4                       	 1000000	      1176 ns/op	     416 B/op	       6 allocs/op
-BenchmarkStructSimpleCustomTypeSuccess-4           	 1000000	      1181 ns/op	      80 B/op	       5 allocs/op
-BenchmarkStructSimpleCustomTypeFailure-4           	 1000000	      1733 ns/op	     592 B/op	      11 allocs/op
-BenchmarkStructPartialSuccess-4                    	 1000000	      1345 ns/op	     400 B/op	      11 allocs/op
-BenchmarkStructPartialFailure-4                    	 1000000	      1905 ns/op	     800 B/op	      16 allocs/op
-BenchmarkStructExceptSuccess-4                     	 2000000	       902 ns/op	     368 B/op	       9 allocs/op
-BenchmarkStructExceptFailure-4                     	 1000000	      1344 ns/op	     400 B/op	      11 allocs/op
-BenchmarkStructSimpleCrossFieldSuccess-4           	 1000000	      1205 ns/op	     128 B/op	       6 allocs/op
-BenchmarkStructSimpleCrossFieldFailure-4           	 1000000	      1779 ns/op	     544 B/op	      11 allocs/op
-BenchmarkStructSimpleCrossStructCrossFieldSuccess-4	 1000000	      1782 ns/op	     160 B/op	       8 allocs/op
-BenchmarkStructSimpleCrossStructCrossFieldFailure-4	 1000000	      2348 ns/op	     576 B/op	      13 allocs/op
-BenchmarkStructSimpleSuccess-4                     	 1000000	      1172 ns/op	      48 B/op	       3 allocs/op
-BenchmarkStructSimpleFailure-4                     	 1000000	      1810 ns/op	     592 B/op	      11 allocs/op
-BenchmarkStructSimpleSuccessParallel-4             	 5000000	       344 ns/op	      48 B/op	       3 allocs/op
-BenchmarkStructSimpleFailureParallel-4             	 2000000	       644 ns/op	     592 B/op	      11 allocs/op
-BenchmarkStructComplexSuccess-4                    	  200000	      7575 ns/op	     432 B/op	      27 allocs/op
-BenchmarkStructComplexFailure-4                    	  100000	     12463 ns/op	    3128 B/op	      69 allocs/op
-BenchmarkStructComplexSuccessParallel-4            	 1000000	      2348 ns/op	     432 B/op	      27 allocs/op
-BenchmarkStructComplexFailureParallel-4            	  300000	      4369 ns/op	    3128 B/op	      69 allocs/op
+BenchmarkFieldSuccess-4                            	 5000000	       296 ns/op	      16 B/op	       1 allocs/op
+BenchmarkFieldFailure-4                            	 5000000	       294 ns/op	      16 B/op	       1 allocs/op
+BenchmarkFieldDiveSuccess-4                        	  500000	      2529 ns/op	     384 B/op	      19 allocs/op
+BenchmarkFieldDiveFailure-4                        	  500000	      3056 ns/op	     768 B/op	      23 allocs/op
+BenchmarkFieldCustomTypeSuccess-4                  	 3000000	       443 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFieldCustomTypeFailure-4                  	 2000000	       753 ns/op	     384 B/op	       4 allocs/op
+BenchmarkFieldOrTagSuccess-4                       	 1000000	      1334 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFieldOrTagFailure-4                       	 1000000	      1172 ns/op	     416 B/op	       6 allocs/op
+BenchmarkStructSimpleCustomTypeSuccess-4           	 1000000	      1206 ns/op	      80 B/op	       5 allocs/op
+BenchmarkStructSimpleCustomTypeFailure-4           	 1000000	      1737 ns/op	     592 B/op	      11 allocs/op
+BenchmarkStructPartialSuccess-4                    	 1000000	      1367 ns/op	     400 B/op	      11 allocs/op
+BenchmarkStructPartialFailure-4                    	 1000000	      1914 ns/op	     800 B/op	      16 allocs/op
+BenchmarkStructExceptSuccess-4                     	 2000000	       909 ns/op	     368 B/op	       9 allocs/op
+BenchmarkStructExceptFailure-4                     	 1000000	      1350 ns/op	     400 B/op	      11 allocs/op
+BenchmarkStructSimpleCrossFieldSuccess-4           	 1000000	      1218 ns/op	     128 B/op	       6 allocs/op
+BenchmarkStructSimpleCrossFieldFailure-4           	 1000000	      1783 ns/op	     544 B/op	      11 allocs/op
+BenchmarkStructSimpleCrossStructCrossFieldSuccess-4	 1000000	      1806 ns/op	     160 B/op	       8 allocs/op
+BenchmarkStructSimpleCrossStructCrossFieldFailure-4	 1000000	      2369 ns/op	     576 B/op	      13 allocs/op
+BenchmarkStructSimpleSuccess-4                     	 1000000	      1161 ns/op	      48 B/op	       3 allocs/op
+BenchmarkStructSimpleFailure-4                     	 1000000	      1813 ns/op	     592 B/op	      11 allocs/op
+BenchmarkStructSimpleSuccessParallel-4             	 5000000	       353 ns/op	      48 B/op	       3 allocs/op
+BenchmarkStructSimpleFailureParallel-4             	 2000000	       656 ns/op	     592 B/op	      11 allocs/op
+BenchmarkStructComplexSuccess-4                    	  200000	      7637 ns/op	     432 B/op	      27 allocs/op
+BenchmarkStructComplexFailure-4                    	  100000	     12775 ns/op	    3128 B/op	      69 allocs/op
+BenchmarkStructComplexSuccessParallel-4            	 1000000	      2270 ns/op	     432 B/op	      27 allocs/op
+BenchmarkStructComplexFailureParallel-4            	  300000	      4328 ns/op	    3128 B/op	      69 allocs/op
 ```
 
 How to Contribute

--- a/README.md
+++ b/README.md
@@ -205,32 +205,32 @@ Benchmarks
 ```go
 $ go test -cpu=4 -bench=. -benchmem=true
 PASS
-BenchmarkFieldSuccess-4                            	 5000000	       285 ns/op	      16 B/op	       1 allocs/op
-BenchmarkFieldFailure-4                            	 5000000	       284 ns/op	      16 B/op	       1 allocs/op
-BenchmarkFieldDiveSuccess-4                        	  500000	      2501 ns/op	     384 B/op	      19 allocs/op
-BenchmarkFieldDiveFailure-4                        	  500000	      3022 ns/op	     752 B/op	      23 allocs/op
-BenchmarkFieldCustomTypeSuccess-4                  	 3000000	       445 ns/op	      32 B/op	       2 allocs/op
-BenchmarkFieldCustomTypeFailure-4                  	 2000000	       788 ns/op	     416 B/op	       6 allocs/op
-BenchmarkFieldOrTagSuccess-4                       	 1000000	      1377 ns/op	      32 B/op	       2 allocs/op
-BenchmarkFieldOrTagFailure-4                       	 1000000	      1201 ns/op	     400 B/op	       6 allocs/op
-BenchmarkStructSimpleCustomTypeSuccess-4           	 1000000	      1257 ns/op	      80 B/op	       5 allocs/op
-BenchmarkStructSimpleCustomTypeFailure-4           	 1000000	      1776 ns/op	     608 B/op	      13 allocs/op
-BenchmarkStructPartialSuccess-4                    	 1000000	      1354 ns/op	     400 B/op	      11 allocs/op
-BenchmarkStructPartialFailure-4                    	 1000000	      1813 ns/op	     784 B/op	      16 allocs/op
-BenchmarkStructExceptSuccess-4                     	 2000000	       916 ns/op	     368 B/op	       9 allocs/op
-BenchmarkStructExceptFailure-4                     	 1000000	      1369 ns/op	     400 B/op	      11 allocs/op
-BenchmarkStructSimpleCrossFieldSuccess-4           	 1000000	      1033 ns/op	     128 B/op	       6 allocs/op
-BenchmarkStructSimpleCrossFieldFailure-4           	 1000000	      1569 ns/op	     528 B/op	      11 allocs/op
-BenchmarkStructSimpleCrossStructCrossFieldSuccess-4	 1000000	      1371 ns/op	     160 B/op	       8 allocs/op
-BenchmarkStructSimpleCrossStructCrossFieldFailure-4	 1000000	      1935 ns/op	     560 B/op	      13 allocs/op
-BenchmarkStructSimpleSuccess-4                     	 1000000	      1161 ns/op	      48 B/op	       3 allocs/op
-BenchmarkStructSimpleFailure-4                     	 1000000	      1720 ns/op	     560 B/op	      11 allocs/op
-BenchmarkStructSimpleSuccessParallel-4             	 5000000	       329 ns/op	      48 B/op	       3 allocs/op
-BenchmarkStructSimpleFailureParallel-4             	 2000000	       625 ns/op	     560 B/op	      11 allocs/op
-BenchmarkStructComplexSuccess-4                    	  200000	      6636 ns/op	     432 B/op	      27 allocs/op
-BenchmarkStructComplexFailure-4                    	  200000	     11327 ns/op	    2919 B/op	      69 allocs/op
-BenchmarkStructComplexSuccessParallel-4            	 1000000	      1991 ns/op	     432 B/op	      27 allocs/op
-BenchmarkStructComplexFailureParallel-4            	  500000	      3854 ns/op	    2920 B/op	      69 allocs/op
+BenchmarkFieldSuccess-4                            	 5000000	       292 ns/op	      16 B/op	       1 allocs/op
+BenchmarkFieldFailure-4                            	 5000000	       291 ns/op	      16 B/op	       1 allocs/op
+BenchmarkFieldDiveSuccess-4                        	  500000	      2518 ns/op	     384 B/op	      19 allocs/op
+BenchmarkFieldDiveFailure-4                        	  500000	      3059 ns/op	     768 B/op	      23 allocs/op
+BenchmarkFieldCustomTypeSuccess-4                  	 3000000	       444 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFieldCustomTypeFailure-4                  	 2000000	       766 ns/op	     384 B/op	       4 allocs/op
+BenchmarkFieldOrTagSuccess-4                       	 1000000	      1344 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFieldOrTagFailure-4                       	 1000000	      1176 ns/op	     416 B/op	       6 allocs/op
+BenchmarkStructSimpleCustomTypeSuccess-4           	 1000000	      1181 ns/op	      80 B/op	       5 allocs/op
+BenchmarkStructSimpleCustomTypeFailure-4           	 1000000	      1733 ns/op	     592 B/op	      11 allocs/op
+BenchmarkStructPartialSuccess-4                    	 1000000	      1345 ns/op	     400 B/op	      11 allocs/op
+BenchmarkStructPartialFailure-4                    	 1000000	      1905 ns/op	     800 B/op	      16 allocs/op
+BenchmarkStructExceptSuccess-4                     	 2000000	       902 ns/op	     368 B/op	       9 allocs/op
+BenchmarkStructExceptFailure-4                     	 1000000	      1344 ns/op	     400 B/op	      11 allocs/op
+BenchmarkStructSimpleCrossFieldSuccess-4           	 1000000	      1205 ns/op	     128 B/op	       6 allocs/op
+BenchmarkStructSimpleCrossFieldFailure-4           	 1000000	      1779 ns/op	     544 B/op	      11 allocs/op
+BenchmarkStructSimpleCrossStructCrossFieldSuccess-4	 1000000	      1782 ns/op	     160 B/op	       8 allocs/op
+BenchmarkStructSimpleCrossStructCrossFieldFailure-4	 1000000	      2348 ns/op	     576 B/op	      13 allocs/op
+BenchmarkStructSimpleSuccess-4                     	 1000000	      1172 ns/op	      48 B/op	       3 allocs/op
+BenchmarkStructSimpleFailure-4                     	 1000000	      1810 ns/op	     592 B/op	      11 allocs/op
+BenchmarkStructSimpleSuccessParallel-4             	 5000000	       344 ns/op	      48 B/op	       3 allocs/op
+BenchmarkStructSimpleFailureParallel-4             	 2000000	       644 ns/op	     592 B/op	      11 allocs/op
+BenchmarkStructComplexSuccess-4                    	  200000	      7575 ns/op	     432 B/op	      27 allocs/op
+BenchmarkStructComplexFailure-4                    	  100000	     12463 ns/op	    3128 B/op	      69 allocs/op
+BenchmarkStructComplexSuccessParallel-4            	 1000000	      2348 ns/op	     432 B/op	      27 allocs/op
+BenchmarkStructComplexFailureParallel-4            	  300000	      4369 ns/op	    3128 B/op	      69 allocs/op
 ```
 
 How to Contribute

--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ Then import the validator package into your own code.
 
 	import "gopkg.in/bluesuncorp/validator.v8"
 
+Error Return Value
+-------
+
+Validation functions return type error
+
+They return type error to avoid the issue discussed in the following, where err is always != nil:
+
+* http://stackoverflow.com/a/29138676/3158232
+* https://github.com/bluesuncorp/validator/issues/134
+
+validator only returns nil or ValidationErrors as type error; so in you code all you need to do
+is check if the error returned is not nil, and if it's not type cast it to type ValidationErrors
+like so:
+
+```go
+err := validate.Struct(mystruct)
+validationErrors := err.(validator.ValidationErrors)
+ ```
+
 Usage and documentation
 ------
 

--- a/baked_in.go
+++ b/baked_in.go
@@ -115,15 +115,15 @@ func isSSN(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Va
 		return false
 	}
 
-	return matchesRegex(sSNRegex, field.String())
+	return sSNRegex.MatchString(field.String())
 }
 
 func isLongitude(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(longitudeRegex, field.String())
+	return longitudeRegex.MatchString(field.String())
 }
 
 func isLatitude(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(latitudeRegex, field.String())
+	return latitudeRegex.MatchString(field.String())
 }
 
 func isDataURI(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
@@ -134,7 +134,7 @@ func isDataURI(v *Validate, topStruct reflect.Value, currentStructOrField reflec
 		return false
 	}
 
-	if !matchesRegex(dataURIRegex, uri[0]) {
+	if !dataURIRegex.MatchString(uri[0]) {
 		return false
 	}
 
@@ -149,31 +149,31 @@ func hasMultiByteCharacter(v *Validate, topStruct reflect.Value, currentStructOr
 		return true
 	}
 
-	return matchesRegex(multibyteRegex, field.String())
+	return multibyteRegex.MatchString(field.String())
 }
 
 func isPrintableASCII(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(printableASCIIRegex, field.String())
+	return printableASCIIRegex.MatchString(field.String())
 }
 
 func isASCII(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(aSCIIRegex, field.String())
+	return aSCIIRegex.MatchString(field.String())
 }
 
 func isUUID5(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(uUID5Regex, field.String())
+	return uUID5Regex.MatchString(field.String())
 }
 
 func isUUID4(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(uUID4Regex, field.String())
+	return uUID4Regex.MatchString(field.String())
 }
 
 func isUUID3(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(uUID3Regex, field.String())
+	return uUID3Regex.MatchString(field.String())
 }
 
 func isUUID(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(uUIDRegex, field.String())
+	return uUIDRegex.MatchString(field.String())
 }
 
 func isISBN(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
@@ -184,7 +184,7 @@ func isISBN13(v *Validate, topStruct reflect.Value, currentStructOrField reflect
 
 	s := strings.Replace(strings.Replace(field.String(), "-", "", 4), " ", "", 4)
 
-	if !matchesRegex(iSBN13Regex, s) {
+	if !iSBN13Regex.MatchString(s) {
 		return false
 	}
 
@@ -208,7 +208,7 @@ func isISBN10(v *Validate, topStruct reflect.Value, currentStructOrField reflect
 
 	s := strings.Replace(strings.Replace(field.String(), "-", "", 3), " ", "", 3)
 
-	if !matchesRegex(iSBN10Regex, s) {
+	if !iSBN10Regex.MatchString(s) {
 		return false
 	}
 
@@ -625,7 +625,7 @@ func isEq(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Val
 }
 
 func isBase64(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(base64Regex, field.String())
+	return base64Regex.MatchString(field.String())
 }
 
 func isURI(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
@@ -663,47 +663,47 @@ func isURL(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Va
 }
 
 func isEmail(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(emailRegex, field.String())
+	return emailRegex.MatchString(field.String())
 }
 
 func isHsla(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(hslaRegex, field.String())
+	return hslaRegex.MatchString(field.String())
 }
 
 func isHsl(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(hslRegex, field.String())
+	return hslRegex.MatchString(field.String())
 }
 
 func isRgba(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(rgbaRegex, field.String())
+	return rgbaRegex.MatchString(field.String())
 }
 
 func isRgb(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(rgbRegex, field.String())
+	return rgbRegex.MatchString(field.String())
 }
 
 func isHexcolor(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(hexcolorRegex, field.String())
+	return hexcolorRegex.MatchString(field.String())
 }
 
 func isHexadecimal(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(hexadecimalRegex, field.String())
+	return hexadecimalRegex.MatchString(field.String())
 }
 
 func isNumber(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(numberRegex, field.String())
+	return numberRegex.MatchString(field.String())
 }
 
 func isNumeric(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(numericRegex, field.String())
+	return numericRegex.MatchString(field.String())
 }
 
 func isAlphanum(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(alphaNumericRegex, field.String())
+	return alphaNumericRegex.MatchString(field.String())
 }
 
 func isAlpha(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	return matchesRegex(alphaRegex, field.String())
+	return alphaRegex.MatchString(field.String())
 }
 
 func hasValue(v *Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {

--- a/baked_in.go
+++ b/baked_in.go
@@ -14,9 +14,7 @@ import (
 // defines a common or complex set of validation(s) to simplify
 // adding validation to structs. i.e. set key "_ageok" and the tags
 // are "gt=0,lte=130" or key "_preferredname" and tags "omitempty,gt=0,lte=60"
-var BakedInAliasValidators = map[string]string{
-	"iscolor": "hexcolor|rgb|rgba|hsl|hsla",
-}
+var BakedInAliasValidators = map[string]string{}
 
 // BakedInValidators is the default map of ValidationFunc
 // you can add, remove or even replace items to suite your needs,

--- a/baked_in.go
+++ b/baked_in.go
@@ -14,14 +14,14 @@ import (
 // defines a common or complex set of validation(s) to simplify
 // adding validation to structs. i.e. set key "_ageok" and the tags
 // are "gt=0,lte=130" or key "_preferredname" and tags "omitempty,gt=0,lte=60"
-var BakedInAliasValidators = map[string]string{
+var bakedInAliasValidators = map[string]string{
 	"iscolor": "hexcolor|rgb|rgba|hsl|hsla",
 }
 
 // BakedInValidators is the default map of ValidationFunc
 // you can add, remove or even replace items to suite your needs,
 // or even disregard and use your own map if so desired.
-var BakedInValidators = map[string]Func{
+var bakedInValidators = map[string]Func{
 	"required":     hasValue,
 	"len":          hasLengthOf,
 	"min":          hasMinOf,

--- a/baked_in.go
+++ b/baked_in.go
@@ -14,7 +14,9 @@ import (
 // defines a common or complex set of validation(s) to simplify
 // adding validation to structs. i.e. set key "_ageok" and the tags
 // are "gt=0,lte=130" or key "_preferredname" and tags "omitempty,gt=0,lte=60"
-var BakedInAliasValidators = map[string]string{}
+var BakedInAliasValidators = map[string]string{
+	"iscolor": "hexcolor|rgb|rgba|hsl|hsla",
+}
 
 // BakedInValidators is the default map of ValidationFunc
 // you can add, remove or even replace items to suite your needs,

--- a/baked_in.go
+++ b/baked_in.go
@@ -10,6 +10,14 @@ import (
 	"unicode/utf8"
 )
 
+// BakedInAliasValidators is a default mapping of a single validationstag that
+// defines a common or complex set of validation(s) to simplify
+// adding validation to structs. i.e. set key "_ageok" and the tags
+// are "gt=0,lte=130" or key "_preferredname" and tags "omitempty,gt=0,lte=60"
+var BakedInAliasValidators = map[string]string{
+	"iscolor": "hexcolor|rgb|rgba|hsl|hsla",
+}
+
 // BakedInValidators is the default map of ValidationFunc
 // you can add, remove or even replace items to suite your needs,
 // or even disregard and use your own map if so desired.

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	sql "database/sql/driver"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -33,11 +32,12 @@ func BenchmarkFieldDiveFailure(b *testing.B) {
 
 func BenchmarkFieldCustomTypeSuccess(b *testing.B) {
 
-	customTypes := map[reflect.Type]CustomTypeFunc{}
-	customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
-	customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
+	// customTypes := map[reflect.Type]CustomTypeFunc{}
+	// customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
+	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
 
-	validate := New(Config{TagName: "validate", ValidationFuncs: BakedInValidators, CustomTypeFuncs: customTypes})
+	validate := New(Config{TagName: "validate"})
+	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
 
 	val := valuer{
 		Name: "1",
@@ -50,11 +50,12 @@ func BenchmarkFieldCustomTypeSuccess(b *testing.B) {
 
 func BenchmarkFieldCustomTypeFailure(b *testing.B) {
 
-	customTypes := map[reflect.Type]CustomTypeFunc{}
-	customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
-	customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
+	// customTypes := map[reflect.Type]CustomTypeFunc{}
+	// customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
+	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
 
-	validate := New(Config{TagName: "validate", ValidationFuncs: BakedInValidators, CustomTypeFuncs: customTypes})
+	validate := New(Config{TagName: "validate"})
+	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
 
 	val := valuer{}
 
@@ -77,11 +78,12 @@ func BenchmarkFieldOrTagFailure(b *testing.B) {
 
 func BenchmarkStructSimpleCustomTypeSuccess(b *testing.B) {
 
-	customTypes := map[reflect.Type]CustomTypeFunc{}
-	customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
-	customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
+	// customTypes := map[reflect.Type]CustomTypeFunc{}
+	// customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
+	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
 
-	validate := New(Config{TagName: "validate", ValidationFuncs: BakedInValidators, CustomTypeFuncs: customTypes})
+	validate := New(Config{TagName: "validate"})
+	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
 
 	val := valuer{
 		Name: "1",
@@ -101,11 +103,12 @@ func BenchmarkStructSimpleCustomTypeSuccess(b *testing.B) {
 
 func BenchmarkStructSimpleCustomTypeFailure(b *testing.B) {
 
-	customTypes := map[reflect.Type]CustomTypeFunc{}
-	customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
-	customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
+	// customTypes := map[reflect.Type]CustomTypeFunc{}
+	// customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
+	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
 
-	validate := New(Config{TagName: "validate", ValidationFuncs: BakedInValidators, CustomTypeFuncs: customTypes})
+	validate := New(Config{TagName: "validate"})
+	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
 
 	val := valuer{}
 

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -32,11 +32,6 @@ func BenchmarkFieldDiveFailure(b *testing.B) {
 
 func BenchmarkFieldCustomTypeSuccess(b *testing.B) {
 
-	// customTypes := map[reflect.Type]CustomTypeFunc{}
-	// customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
-	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
-
-	validate := New(Config{TagName: "validate"})
 	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
 
 	val := valuer{
@@ -50,11 +45,7 @@ func BenchmarkFieldCustomTypeSuccess(b *testing.B) {
 
 func BenchmarkFieldCustomTypeFailure(b *testing.B) {
 
-	// customTypes := map[reflect.Type]CustomTypeFunc{}
-	// customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
-	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
-
-	validate := New(Config{TagName: "validate"})
+	// validate := New(Config{TagName: "validate"})
 	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
 
 	val := valuer{}
@@ -78,11 +69,6 @@ func BenchmarkFieldOrTagFailure(b *testing.B) {
 
 func BenchmarkStructSimpleCustomTypeSuccess(b *testing.B) {
 
-	// customTypes := map[reflect.Type]CustomTypeFunc{}
-	// customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
-	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
-
-	validate := New(Config{TagName: "validate"})
 	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
 
 	val := valuer{
@@ -103,11 +89,6 @@ func BenchmarkStructSimpleCustomTypeSuccess(b *testing.B) {
 
 func BenchmarkStructSimpleCustomTypeFailure(b *testing.B) {
 
-	// customTypes := map[reflect.Type]CustomTypeFunc{}
-	// customTypes[reflect.TypeOf((*sql.Valuer)(nil))] = ValidateValuerType
-	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
-
-	validate := New(Config{TagName: "validate"})
 	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
 
 	val := valuer{}

--- a/doc.go
+++ b/doc.go
@@ -18,6 +18,9 @@ I needed to know the field and what validation failed so that I could provide an
 
 Validation functions return type error
 
+Doing things this way is actually the way the standard library does, see the file.Open
+method here: https://golang.org/pkg/os/#Open.
+
 They return type error to avoid the issue discussed in the following, where err is always != nil:
 http://stackoverflow.com/a/29138676/3158232
 https://github.com/bluesuncorp/validator/issues/134

--- a/doc.go
+++ b/doc.go
@@ -16,6 +16,16 @@ I needed to know the field and what validation failed so that I could provide an
 		return "Translated string based on field"
 	}
 
+Validation functions return type error
+
+They return type error to avoid the issue discussed in the following, where err is always != nil:
+http://stackoverflow.com/a/29138676/3158232
+https://github.com/bluesuncorp/validator/issues/134
+
+validator only returns nil or ValidationErrors as type error; so in you code all you need to do
+is check if the error returned is not nil, and if it's not type cast it to type ValidationErrors
+like so err.(validator.ValidationErrors)
+
 Custom Functions
 
 Custom functions can be added

--- a/doc.go
+++ b/doc.go
@@ -445,6 +445,18 @@ Here is a list of the current built in validators:
 		http://golang.org/src/net/mac.go?s=866:918#L29
 		(Usage: mac)
 
+Alias Validators and Tags
+
+NOTE: when returning an error the tag returned in FieldError will be
+the alias tag unless the dive tag is part of the alias; everything after the
+dive tag is not reported as the alias tag. Also the ActualTag in the before case
+will be the actual tag within the alias that failed.
+
+Here is a list of the current built in alias tags:
+
+	iscolor
+		alias is "hexcolor|rgb|rgba|hsl|hsla" (Usage: iscolor)
+
 Validator notes:
 
 	regex

--- a/examples_test.go
+++ b/examples_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ExampleValidate_new() {
-	config := validator.Config{TagName: "validate"}
+	config := &validator.Config{TagName: "validate"}
 
 	validator.New(config)
 }
@@ -17,7 +17,7 @@ func ExampleValidate_field() {
 	// This should be stored somewhere globally
 	var validate *validator.Validate
 
-	config := validator.Config{TagName: "validate"}
+	config := &validator.Config{TagName: "validate"}
 
 	validate = validator.New(config)
 
@@ -43,7 +43,7 @@ func ExampleValidate_struct() {
 	// This should be stored somewhere globally
 	var validate *validator.Validate
 
-	config := validator.Config{TagName: "validate"}
+	config := &validator.Config{TagName: "validate"}
 
 	validate = validator.New(config)
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -3,14 +3,12 @@ package validator_test
 import (
 	"fmt"
 
-	"gopkg.in/bluesuncorp/validator.v7"
+	// "gopkg.in/bluesuncorp/validator.v7"
+	"../validator"
 )
 
 func ExampleValidate_new() {
-	config := validator.Config{
-		TagName:         "validate",
-		ValidationFuncs: validator.BakedInValidators,
-	}
+	config := validator.Config{TagName: "validate"}
 
 	validator.New(config)
 }
@@ -19,16 +17,13 @@ func ExampleValidate_field() {
 	// This should be stored somewhere globally
 	var validate *validator.Validate
 
-	config := validator.Config{
-		TagName:         "validate",
-		ValidationFuncs: validator.BakedInValidators,
-	}
+	config := validator.Config{TagName: "validate"}
 
 	validate = validator.New(config)
 
 	i := 0
 	errs := validate.Field(i, "gt=1,lte=10")
-	err := errs[""]
+	err := errs.(validator.ValidationErrors)[""]
 	fmt.Println(err.Field)
 	fmt.Println(err.Tag)
 	fmt.Println(err.Kind) // NOTE: Kind and Type can be different i.e. time Kind=struct and Type=time.Time
@@ -48,10 +43,7 @@ func ExampleValidate_struct() {
 	// This should be stored somewhere globally
 	var validate *validator.Validate
 
-	config := validator.Config{
-		TagName:         "validate",
-		ValidationFuncs: validator.BakedInValidators,
-	}
+	config := validator.Config{TagName: "validate"}
 
 	validate = validator.New(config)
 
@@ -81,7 +73,7 @@ func ExampleValidate_struct() {
 	}
 
 	errs := validate.Struct(user)
-	for _, v := range errs {
+	for _, v := range errs.(validator.ValidationErrors) {
 		fmt.Println(v.Field) // Phone
 		fmt.Println(v.Tag)   // required
 		//... and so forth

--- a/regexes.go
+++ b/regexes.go
@@ -57,7 +57,3 @@ var (
 	longitudeRegex      = regexp.MustCompile(longitudeRegexString)
 	sSNRegex            = regexp.MustCompile(sSNRegexString)
 )
-
-func matchesRegex(regex *regexp.Regexp, value string) bool {
-	return regex.MatchString(value)
-}

--- a/util.go
+++ b/util.go
@@ -54,7 +54,7 @@ func (v *Validate) extractType(current reflect.Value) (reflect.Value, reflect.Ki
 	default:
 
 		if v.config.hasCustomFuncs {
-			if fn, ok := v.config.CustomTypeFuncs[current.Type()]; ok {
+			if fn, ok := v.config.customTypeFuncs[current.Type()]; ok {
 				return v.extractType(reflect.ValueOf(fn(current)))
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -53,8 +53,8 @@ func (v *Validate) extractType(current reflect.Value) (reflect.Value, reflect.Ki
 
 	default:
 
-		if v.config.hasCustomFuncs {
-			if fn, ok := v.config.customTypeFuncs[current.Type()]; ok {
+		if v.hasCustomFuncs {
+			if fn, ok := v.customTypeFuncs[current.Type()]; ok {
 				return v.extractType(reflect.ValueOf(fn(current)))
 			}
 		}
@@ -248,9 +248,9 @@ func (v *Validate) parseTagsRecursive(cTag *cachedTag, tag, fieldName, alias str
 
 	for _, t := range strings.Split(tag, tagSeparator) {
 
-		if v.config.hasAliasValidators {
+		if v.hasAliasValidators {
 			// check map for alias and process new tags, otherwise process as usual
-			if tagsVal, ok := v.config.aliasValidators[t]; ok {
+			if tagsVal, ok := v.aliasValidators[t]; ok {
 
 				leave := v.parseTagsRecursive(cTag, tagsVal, fieldName, t, true)
 

--- a/validator.go
+++ b/validator.go
@@ -141,9 +141,6 @@ type FieldError struct {
 // New creates a new Validate instance for use.
 func New(config *Config) *Validate {
 
-	// if config.CustomTypeFuncs != nil && len(config.CustomTypeFuncs) > 0 {
-	// 	config.hasCustomFuncs = true
-	// }
 	v := &Validate{
 		tagName:   config.TagName,
 		tagsCache: &tagCacheMap{m: map[string]*cachedTag{}},
@@ -152,7 +149,7 @@ func New(config *Config) *Validate {
 		}}}
 
 	if len(v.aliasValidators) == 0 {
-		// must copy validators for separate validations to be used in each validator instance
+		// must copy alias validators for separate validations to be used in each validator instance
 		v.aliasValidators = map[string]string{}
 		for k, val := range bakedInAliasValidators {
 			v.RegisterAliasValidation(k, val)

--- a/validator.go
+++ b/validator.go
@@ -82,7 +82,7 @@ func (s *tagCacheMap) Set(key string, value *cachedTag) {
 
 // Validate contains the validator settings passed in using the Config struct
 type Validate struct {
-	config             Config
+	tagName            string
 	validationFuncs    map[string]Func
 	customTypeFuncs    map[reflect.Type]CustomTypeFunc
 	aliasValidators    map[string]string
@@ -144,12 +144,12 @@ type FieldError struct {
 }
 
 // New creates a new Validate instance for use.
-func New(config Config) *Validate {
+func New(config *Config) *Validate {
 
 	// if config.CustomTypeFuncs != nil && len(config.CustomTypeFuncs) > 0 {
 	// 	config.hasCustomFuncs = true
 	// }
-	v := &Validate{config: config, tagsCache: &tagCacheMap{m: map[string]*cachedTag{}}}
+	v := &Validate{tagName: config.TagName, tagsCache: &tagCacheMap{m: map[string]*cachedTag{}}}
 
 	if len(v.aliasValidators) == 0 {
 		// must copy validators for separate validations to be used in each validator instance
@@ -403,7 +403,7 @@ func (v *Validate) tranverseStruct(topStruct reflect.Value, currentStruct reflec
 			}
 		}
 
-		v.traverseField(topStruct, currentStruct, current.Field(i), errPrefix, errs, true, fld.Tag.Get(v.config.TagName), fld.Name, partial, exclude, includeExclude)
+		v.traverseField(topStruct, currentStruct, current.Field(i), errPrefix, errs, true, fld.Tag.Get(v.tagName), fld.Name, partial, exclude, includeExclude)
 	}
 }
 

--- a/validator.go
+++ b/validator.go
@@ -169,7 +169,7 @@ func New(config *Config) *Validate {
 
 // RegisterValidation adds a validation Func to a Validate's map of validators denoted by the key
 // NOTE: if the key already exists, the previous validation function will be replaced.
-// NOTE: this method is not thread-safe
+// NOTE: this method is not thread-safe it is intended that these all be registered prior to any validation
 func (v *Validate) RegisterValidation(key string, f Func) error {
 
 	if len(key) == 0 {
@@ -192,6 +192,7 @@ func (v *Validate) RegisterValidation(key string, f Func) error {
 }
 
 // RegisterCustomTypeFunc registers a CustomTypeFunc against a number of types
+// NOTE: this method is not thread-safe it is intended that these all be registered prior to any validation
 func (v *Validate) RegisterCustomTypeFunc(fn CustomTypeFunc, types ...interface{}) {
 
 	if v.customTypeFuncs == nil {
@@ -211,6 +212,7 @@ func (v *Validate) RegisterCustomTypeFunc(fn CustomTypeFunc, types ...interface{
 // the alias tag unless the dive tag is part of the alias; everything after the
 // dive tag is not reported as the alias tag. Also the ActualTag in the before case
 // will be the actual tag within the alias that failed.
+// NOTE: this method is not thread-safe it is intended that these all be registered prior to any validation
 func (v *Validate) RegisterAliasValidation(alias, tags string) {
 
 	_, ok := restrictedTags[alias]

--- a/validator.go
+++ b/validator.go
@@ -55,6 +55,7 @@ type tagCache struct {
 	isOrVal bool
 	isAlias bool
 	tag     string
+	diveTag string
 	// actualTag string
 }
 
@@ -191,8 +192,12 @@ func (v *Validate) RegisterCustomTypeFunc(fn CustomTypeFunc, types ...interface{
 // to structs.
 func (v *Validate) RegisterAliasValidation(alias, tags string) {
 
-	if v.config.aliasValidators == nil {
+	if len(v.config.aliasValidators) == 0 {
+		// must copy validators for separate validations to be used in each
 		v.config.aliasValidators = map[string]string{}
+		for k, val := range BakedInAliasValidators {
+			v.config.aliasValidators[k] = val
+		}
 	}
 
 	_, ok := restrictedTags[alias]
@@ -471,7 +476,8 @@ func (v *Validate) traverseField(topStruct reflect.Value, currentStruct reflect.
 
 		if cTag.tagVals[0][0] == diveTag {
 			dive = true
-			diveSubTag = strings.TrimLeft(strings.SplitN(tag, diveTag, 2)[1], ",")
+			// fmt.Println(cTag.diveTag)
+			diveSubTag = strings.TrimLeft(strings.SplitN(cTag.diveTag, diveTag, 2)[1], ",")
 			break
 		}
 

--- a/validator.go
+++ b/validator.go
@@ -189,7 +189,10 @@ func (v *Validate) RegisterCustomTypeFunc(fn CustomTypeFunc, types ...interface{
 
 // RegisterAliasValidation registers a mapping of a single validationstag that
 // defines a common or complex set of validation(s) to simplify adding validation
-// to structs.
+// to structs. NOTE: when returning an error the tag returned in FieldError will be
+// the alias tag unless the dive tag is part of the alias; everything after the
+// dive tag is not reported as the alias tag. Also the ActualTag in the before case
+// will be the actual tag within the alias that failed.
 func (v *Validate) RegisterAliasValidation(alias, tags string) {
 
 	if len(v.config.aliasValidators) == 0 {

--- a/validator.go
+++ b/validator.go
@@ -149,24 +149,25 @@ func New(config Config) *Validate {
 	// if config.CustomTypeFuncs != nil && len(config.CustomTypeFuncs) > 0 {
 	// 	config.hasCustomFuncs = true
 	// }
+	v := &Validate{config: config}
 
-	if len(config.aliasValidators) == 0 {
+	if len(v.config.aliasValidators) == 0 {
 		// must copy validators for separate validations to be used in each
-		config.aliasValidators = map[string]string{}
+		v.config.aliasValidators = map[string]string{}
 		for k, val := range BakedInAliasValidators {
-			config.aliasValidators[k] = val
+			v.RegisterAliasValidation(k, val)
 		}
 	}
 
-	if len(config.validationFuncs) == 0 {
+	if len(v.config.validationFuncs) == 0 {
 		// must copy validators for separate validations to be used in each
-		config.validationFuncs = map[string]Func{}
+		v.config.validationFuncs = map[string]Func{}
 		for k, val := range BakedInValidators {
-			config.validationFuncs[k] = val
+			v.RegisterValidation(k, val)
 		}
 	}
 
-	return &Validate{config: config}
+	return v
 }
 
 // RegisterValidation adds a validation Func to a Validate's map of validators denoted by the key

--- a/validator_test.go
+++ b/validator_test.go
@@ -113,7 +113,9 @@ type TestSlice struct {
 
 var validate = New(Config{TagName: "validate"})
 
-func AssertError(t *testing.T, errs ValidationErrors, key, field, expectedTag string) {
+func AssertError(t *testing.T, err error, key, field, expectedTag string) {
+
+	errs := err.(ValidationErrors)
 
 	val, ok := errs[key]
 	EqualSkip(t, 2, ok, true)
@@ -242,7 +244,7 @@ func TestAliasTags(t *testing.T) {
 	errs = validate.Struct(tst)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test.Color", "Color", "iscolor")
-	Equal(t, errs["Test.Color"].ActualTag, "hexcolor|rgb|rgba|hsl|hsla")
+	Equal(t, errs.(ValidationErrors)["Test.Color"].ActualTag, "hexcolor|rgb|rgba|hsl|hsla")
 
 	validate.RegisterAliasValidation("req", "required,dive,iscolor")
 	arr := []string{"val1", "#fff", "#000"}
@@ -397,12 +399,12 @@ func TestStructPartial(t *testing.T) {
 	// these will fail as unset item IS tested
 	errs = validate.StructExcept(tPartial, p1...)
 	AssertError(t, errs, "TestPartial.SubSlice[0].Test", "Test", "required")
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 
 	errs = validate.StructPartial(tPartial, p2...)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TestPartial.SubSlice[0].Test", "Test", "required")
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 
 	// Unset second slice member concurrently to test dive behavior:
 	tPartial.SubSlice[1].Test = ""
@@ -417,13 +419,13 @@ func TestStructPartial(t *testing.T) {
 	AssertError(t, errs, "TestPartial.SubSlice[1].Test", "Test", "required")
 
 	errs = validate.StructExcept(tPartial, p1...)
-	Equal(t, len(errs), 2)
+	Equal(t, len(errs.(ValidationErrors)), 2)
 	AssertError(t, errs, "TestPartial.SubSlice[0].Test", "Test", "required")
 	AssertError(t, errs, "TestPartial.SubSlice[1].Test", "Test", "required")
 
 	errs = validate.StructPartial(tPartial, p2...)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "TestPartial.SubSlice[0].Test", "Test", "required")
 
 	// reset struct in slice, and unset struct in slice in unset posistion
@@ -439,7 +441,7 @@ func TestStructPartial(t *testing.T) {
 	// testing for missing item by exception, yes it dives and fails
 	errs = validate.StructExcept(tPartial, p1...)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "TestPartial.SubSlice[1].Test", "Test", "required")
 
 	errs = validate.StructExcept(tPartial, p2...)
@@ -1303,7 +1305,7 @@ func TestSQLValue2Validation(t *testing.T) {
 
 	errs = validate.Struct(c)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 2)
+	Equal(t, len(errs.(ValidationErrors)), 2)
 	AssertError(t, errs, "CustomMadeUpStruct.MadeUp", "MadeUp", "required")
 	AssertError(t, errs, "CustomMadeUpStruct.OverriddenInt", "OverriddenInt", "gt")
 }
@@ -1362,7 +1364,7 @@ func TestSQLValueValidation(t *testing.T) {
 
 	errs = validate.Struct(c)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 2)
+	Equal(t, len(errs.(ValidationErrors)), 2)
 	AssertError(t, errs, "CustomMadeUpStruct.MadeUp", "MadeUp", "required")
 	AssertError(t, errs, "CustomMadeUpStruct.OverriddenInt", "OverriddenInt", "gt")
 }
@@ -1393,7 +1395,7 @@ func TestMACValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d mac failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "mac" {
 					t.Fatalf("Index: %d mac failed Error: %s", i, errs)
 				}
@@ -1431,7 +1433,7 @@ func TestIPValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d ip failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "ip" {
 					t.Fatalf("Index: %d ip failed Error: %s", i, errs)
 				}
@@ -1469,7 +1471,7 @@ func TestIPv6Validation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d ipv6 failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "ipv6" {
 					t.Fatalf("Index: %d ipv6 failed Error: %s", i, errs)
 				}
@@ -1507,7 +1509,7 @@ func TestIPv4Validation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d ipv4 failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "ipv4" {
 					t.Fatalf("Index: %d ipv4 failed Error: %s", i, errs)
 				}
@@ -1664,7 +1666,7 @@ func TestInterfaceErrValidation(t *testing.T) {
 
 	errs = validate.Struct(s)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "ExternalCMD.Data", "Data", "required")
 
 	type ExternalCMD2 struct {
@@ -1681,7 +1683,7 @@ func TestInterfaceErrValidation(t *testing.T) {
 
 	errs = validate.Struct(s2)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "ExternalCMD2.Data", "Data", "len")
 
 	s3 := &ExternalCMD2{
@@ -1692,7 +1694,7 @@ func TestInterfaceErrValidation(t *testing.T) {
 
 	errs = validate.Struct(s3)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "ExternalCMD2.Data", "Data", "len")
 
 	type Inner struct {
@@ -1711,7 +1713,7 @@ func TestInterfaceErrValidation(t *testing.T) {
 
 	errs = validate.Struct(s4)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "ExternalCMD.Data.Name", "Name", "required")
 
 	type TestMapStructPtr struct {
@@ -1726,7 +1728,7 @@ func TestInterfaceErrValidation(t *testing.T) {
 
 	errs = validate.Struct(msp)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "TestMapStructPtr.Errs[3]", "Errs[3]", "len")
 
 	type TestMultiDimensionalStructs struct {
@@ -1744,7 +1746,7 @@ func TestInterfaceErrValidation(t *testing.T) {
 
 	errs = validate.Struct(tms)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 4)
+	Equal(t, len(errs.(ValidationErrors)), 4)
 	AssertError(t, errs, "TestMultiDimensionalStructs.Errs[0][1].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructs.Errs[0][2].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructs.Errs[1][1].Name", "Name", "required")
@@ -1766,7 +1768,7 @@ func TestInterfaceErrValidation(t *testing.T) {
 
 	errs = validate.Struct(tmsp2)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 6)
+	Equal(t, len(errs.(ValidationErrors)), 6)
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr2.Errs[0][1].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr2.Errs[0][2].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr2.Errs[1][1].Name", "Name", "required")
@@ -1778,24 +1780,24 @@ func TestInterfaceErrValidation(t *testing.T) {
 
 	errs = validate.Field(m, "len=3,dive,len=2")
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "[3]", "[3]", "len")
 
 	errs = validate.Field(m, "len=2,dive,required")
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "", "", "len")
 
 	arr := []interface{}{"ok", "", "ok"}
 
 	errs = validate.Field(arr, "len=3,dive,len=2")
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "[1]", "[1]", "len")
 
 	errs = validate.Field(arr, "len=2,dive,required")
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "", "", "len")
 
 	type MyStruct struct {
@@ -1822,12 +1824,12 @@ func TestMapDiveValidation(t *testing.T) {
 
 	errs = validate.Field(m, "len=3,dive,required")
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "[3]", "[3]", "required")
 
 	errs = validate.Field(m, "len=2,dive,required")
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "", "", "len")
 
 	type Inner struct {
@@ -1846,7 +1848,7 @@ func TestMapDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(ms)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "TestMapStruct.Errs[3].Name", "Name", "required")
 
 	// for full test coverage
@@ -1867,7 +1869,7 @@ func TestMapDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(mt)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 2)
+	Equal(t, len(errs.(ValidationErrors)), 2)
 	AssertError(t, errs, "TestMapTimeStruct.Errs[3]", "Errs[3]", "required")
 	AssertError(t, errs, "TestMapTimeStruct.Errs[4]", "Errs[4]", "required")
 
@@ -1883,7 +1885,7 @@ func TestMapDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(msp)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "TestMapStructPtr.Errs[3]", "Errs[3]", "required")
 
 	type TestMapStructPtr2 struct {
@@ -1906,12 +1908,12 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs := validate.Field(arr, "len=3,dive,required")
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "[1]", "[1]", "required")
 
 	errs = validate.Field(arr, "len=2,dive,required")
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "", "", "len")
 
 	type BadDive struct {
@@ -1934,7 +1936,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(test)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "Test.Errs[1]", "Errs[1]", "required")
 
 	test = &Test{
@@ -1943,7 +1945,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(test)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 1)
+	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "Test.Errs[2]", "Errs[2]", "required")
 
 	type TestMultiDimensional struct {
@@ -1961,7 +1963,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(tm)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 4)
+	Equal(t, len(errs.(ValidationErrors)), 4)
 	AssertError(t, errs, "TestMultiDimensional.Errs[0][1]", "Errs[0][1]", "required")
 	AssertError(t, errs, "TestMultiDimensional.Errs[0][2]", "Errs[0][2]", "required")
 	AssertError(t, errs, "TestMultiDimensional.Errs[1][1]", "Errs[1][1]", "required")
@@ -1986,7 +1988,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(tms)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 4)
+	Equal(t, len(errs.(ValidationErrors)), 4)
 	AssertError(t, errs, "TestMultiDimensionalStructs.Errs[0][1].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructs.Errs[0][2].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructs.Errs[1][1].Name", "Name", "required")
@@ -2008,7 +2010,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(tmsp)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 5)
+	Equal(t, len(errs.(ValidationErrors)), 5)
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr.Errs[0][1].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr.Errs[0][2].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr.Errs[1][1].Name", "Name", "required")
@@ -2035,7 +2037,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(tmsp2)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 6)
+	Equal(t, len(errs.(ValidationErrors)), 6)
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr2.Errs[0][1].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr2.Errs[0][2].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr2.Errs[1][1].Name", "Name", "required")
@@ -2059,7 +2061,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(tmsp3)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 5)
+	Equal(t, len(errs.(ValidationErrors)), 5)
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr3.Errs[0][1].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr3.Errs[0][2].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr3.Errs[1][1].Name", "Name", "required")
@@ -2086,7 +2088,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(tmtp3)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 3)
+	Equal(t, len(errs.(ValidationErrors)), 3)
 	AssertError(t, errs, "TestMultiDimensionalTimeTime.Errs[1][2]", "Errs[1][2]", "required")
 	AssertError(t, errs, "TestMultiDimensionalTimeTime.Errs[2][1]", "Errs[2][1]", "required")
 	AssertError(t, errs, "TestMultiDimensionalTimeTime.Errs[2][2]", "Errs[2][2]", "required")
@@ -2111,7 +2113,7 @@ func TestArrayDiveValidation(t *testing.T) {
 
 	errs = validate.Struct(tmtp)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 3)
+	Equal(t, len(errs.(ValidationErrors)), 3)
 	AssertError(t, errs, "TestMultiDimensionalTimeTime2.Errs[1][2]", "Errs[1][2]", "required")
 	AssertError(t, errs, "TestMultiDimensionalTimeTime2.Errs[2][1]", "Errs[2][1]", "required")
 	AssertError(t, errs, "TestMultiDimensionalTimeTime2.Errs[2][2]", "Errs[2][2]", "required")
@@ -2234,7 +2236,7 @@ func TestSSNValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d SSN failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "ssn" {
 					t.Fatalf("Index: %d Latitude failed Error: %s", i, errs)
 				}
@@ -2268,7 +2270,7 @@ func TestLongitudeValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d Longitude failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "longitude" {
 					t.Fatalf("Index: %d Latitude failed Error: %s", i, errs)
 				}
@@ -2302,7 +2304,7 @@ func TestLatitudeValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d Latitude failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "latitude" {
 					t.Fatalf("Index: %d Latitude failed Error: %s", i, errs)
 				}
@@ -2342,7 +2344,7 @@ func TestDataURIValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d DataURI failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "datauri" {
 					t.Fatalf("Index: %d DataURI failed Error: %s", i, errs)
 				}
@@ -2380,7 +2382,7 @@ func TestMultibyteValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d Multibyte failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "multibyte" {
 					t.Fatalf("Index: %d Multibyte failed Error: %s", i, errs)
 				}
@@ -2419,7 +2421,7 @@ func TestPrintableASCIIValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d Printable ASCII failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "printascii" {
 					t.Fatalf("Index: %d Printable ASCII failed Error: %s", i, errs)
 				}
@@ -2457,7 +2459,7 @@ func TestASCIIValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d ASCII failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "ascii" {
 					t.Fatalf("Index: %d ASCII failed Error: %s", i, errs)
 				}
@@ -2492,7 +2494,7 @@ func TestUUID5Validation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d UUID5 failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "uuid5" {
 					t.Fatalf("Index: %d UUID5 failed Error: %s", i, errs)
 				}
@@ -2526,7 +2528,7 @@ func TestUUID4Validation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d UUID4 failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "uuid4" {
 					t.Fatalf("Index: %d UUID4 failed Error: %s", i, errs)
 				}
@@ -2559,7 +2561,7 @@ func TestUUID3Validation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d UUID3 failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "uuid3" {
 					t.Fatalf("Index: %d UUID3 failed Error: %s", i, errs)
 				}
@@ -2595,7 +2597,7 @@ func TestUUIDValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d UUID failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "uuid" {
 					t.Fatalf("Index: %d UUID failed Error: %s", i, errs)
 				}
@@ -2633,7 +2635,7 @@ func TestISBNValidation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d ISBN failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "isbn" {
 					t.Fatalf("Index: %d ISBN failed Error: %s", i, errs)
 				}
@@ -2670,7 +2672,7 @@ func TestISBN13Validation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d ISBN13 failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "isbn13" {
 					t.Fatalf("Index: %d ISBN13 failed Error: %s", i, errs)
 				}
@@ -2708,7 +2710,7 @@ func TestISBN10Validation(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d ISBN10 failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "isbn10" {
 					t.Fatalf("Index: %d ISBN10 failed Error: %s", i, errs)
 				}
@@ -4177,7 +4179,7 @@ func TestUrl(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d URL failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "url" {
 					t.Fatalf("Index: %d URL failed Error: %s", i, errs)
 				}
@@ -4241,7 +4243,7 @@ func TestUri(t *testing.T) {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d URI failed Error: %s", i, errs)
 			} else {
-				val := errs[""]
+				val := errs.(ValidationErrors)[""]
 				if val.Tag != "uri" {
 					t.Fatalf("Index: %d URI failed Error: %s", i, errs)
 				}
@@ -4707,7 +4709,7 @@ func TestStructStringValidation(t *testing.T) {
 
 	// Assert Top Level
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 13)
+	Equal(t, len(errs.(ValidationErrors)), 13)
 
 	// Assert Fields
 	AssertError(t, errs, "TestString.Required", "Required", "required")
@@ -4762,7 +4764,7 @@ func TestStructInt32Validation(t *testing.T) {
 
 	// Assert Top Level
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 10)
+	Equal(t, len(errs.(ValidationErrors)), 10)
 
 	// Assert Fields
 	AssertError(t, errs, "TestInt32.Required", "Required", "required")
@@ -4804,7 +4806,7 @@ func TestStructUint64Validation(t *testing.T) {
 
 	// Assert Top Level
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 6)
+	Equal(t, len(errs.(ValidationErrors)), 6)
 
 	// Assert Fields
 	AssertError(t, errs, "TestUint64.Required", "Required", "required")
@@ -4842,7 +4844,7 @@ func TestStructFloat64Validation(t *testing.T) {
 
 	// Assert Top Level
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 6)
+	Equal(t, len(errs.(ValidationErrors)), 6)
 
 	// Assert Fields
 	AssertError(t, errs, "TestFloat64.Required", "Required", "required")
@@ -4878,7 +4880,7 @@ func TestStructSliceValidation(t *testing.T) {
 
 	errs = validate.Struct(tFail)
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs), 6)
+	Equal(t, len(errs.(ValidationErrors)), 6)
 
 	// Assert Field Errors
 	AssertError(t, errs, "TestSlice.Required", "Required", "required")

--- a/validator_test.go
+++ b/validator_test.go
@@ -111,7 +111,7 @@ type TestSlice struct {
 	OmitEmpty []int `validate:"omitempty,min=1,max=10"`
 }
 
-var validate = New(Config{TagName: "validate", ValidationFuncs: BakedInValidators})
+var validate = New(Config{TagName: "validate", ValidationFuncs: BakedInValidators, AliasValidators: BakedInAliasValidators})
 
 func AssertError(t *testing.T, errs ValidationErrors, key, field, expectedTag string) {
 
@@ -208,6 +208,24 @@ type TestPartial struct {
 			OtherTest string `validate:"required"`
 		} `validate:"required,dive"`
 	}
+}
+
+func TestAliasTags(t *testing.T) {
+
+	s := "rgb(255,255,255)"
+	errs := validate.Field(s, "iscolor")
+	Equal(t, errs, nil)
+
+	type Test struct {
+		Color string `vlidate:"iscolor"`
+	}
+
+	tst := &Test{
+		Color: "#000",
+	}
+
+	errs = validate.Struct(tst)
+	Equal(t, errs, nil)
 }
 
 func TestStructPartial(t *testing.T) {
@@ -1805,7 +1823,8 @@ func TestMapDiveValidation(t *testing.T) {
 	AssertError(t, errs, "TestMapStruct.Errs[3].Name", "Name", "required")
 
 	// for full test coverage
-	fmt.Sprint(errs.Error())
+	s := fmt.Sprint(errs.Error())
+	NotEqual(t, s, "")
 
 	type TestMapTimeStruct struct {
 		Errs map[int]*time.Time `validate:"gt=0,dive,required"`
@@ -1968,8 +1987,10 @@ func TestArrayDiveValidation(t *testing.T) {
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr.Errs[1][1].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr.Errs[1][2].Name", "Name", "required")
 	AssertError(t, errs, "TestMultiDimensionalStructsPtr.Errs[2][1].Name", "Name", "required")
+
 	// for full test coverage
-	fmt.Sprint(errs.Error())
+	s := fmt.Sprint(errs.Error())
+	NotEqual(t, s, "")
 
 	type TestMultiDimensionalStructsPtr2 struct {
 		Errs [][]*Inner `validate:"gt=0,dive,dive,required"`

--- a/validator_test.go
+++ b/validator_test.go
@@ -243,6 +243,14 @@ func TestAliasTags(t *testing.T) {
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test.Color", "Color", "iscolor")
 	Equal(t, errs["Test.Color"].ActualTag, "hexcolor|rgb|rgba|hsl|hsla")
+
+	validate.RegisterAliasValidation("req", "required,dive,iscolor")
+	arr := []string{"val1", "#fff", "#000"}
+	errs = validate.Field(arr, "req")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "[0]", "[0]", "iscolor")
+
+	PanicMatches(t, func() { validate.RegisterAliasValidation("exists", "gt=5,lt=10") }, "Alias \"exists\" either contains restricted characters or is the same as a restricted tag needed for normal operation")
 }
 
 func TestStructPartial(t *testing.T) {
@@ -3881,6 +3889,8 @@ func TestAddFunctions(t *testing.T) {
 
 	errs = validate.RegisterValidation("new", fn)
 	Equal(t, errs, nil)
+
+	PanicMatches(t, func() { validate.RegisterValidation("dive", fn) }, "Tag \"dive\" either contains restricted characters or is the same as a restricted tag needed for normal operation")
 }
 
 func TestChangeTag(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -111,7 +111,7 @@ type TestSlice struct {
 	OmitEmpty []int `validate:"omitempty,min=1,max=10"`
 }
 
-var validate = New(Config{TagName: "validate"})
+var validate = New(&Config{TagName: "validate"})
 
 func AssertError(t *testing.T, err error, key, field, expectedTag string) {
 
@@ -1255,7 +1255,7 @@ func TestExistsValidation(t *testing.T) {
 
 func TestSQLValue2Validation(t *testing.T) {
 
-	config := Config{
+	config := &Config{
 		TagName: "validate",
 	}
 
@@ -1318,7 +1318,7 @@ func TestSQLValueValidation(t *testing.T) {
 	// customTypes[reflect.TypeOf(MadeUpCustomType{})] = ValidateCustomType
 	// customTypes[reflect.TypeOf(1)] = OverrideIntTypeForSomeReason
 
-	validate := New(Config{TagName: "validate"})
+	validate := New(&Config{TagName: "validate"})
 	validate.RegisterCustomTypeFunc(ValidateValuerType, (*driver.Valuer)(nil), valuer{})
 	validate.RegisterCustomTypeFunc(ValidateCustomType, MadeUpCustomType{})
 	validate.RegisterCustomTypeFunc(OverrideIntTypeForSomeReason, 1)
@@ -3875,7 +3875,7 @@ func TestAddFunctions(t *testing.T) {
 		return true
 	}
 
-	config := Config{
+	config := &Config{
 		TagName: "validateme",
 	}
 
@@ -3898,7 +3898,7 @@ func TestAddFunctions(t *testing.T) {
 
 func TestChangeTag(t *testing.T) {
 
-	config := Config{
+	config := &Config{
 		TagName: "val",
 	}
 	validate := New(config)

--- a/validator_test.go
+++ b/validator_test.go
@@ -111,7 +111,7 @@ type TestSlice struct {
 	OmitEmpty []int `validate:"omitempty,min=1,max=10"`
 }
 
-var validate = New(Config{TagName: "validate", ValidationFuncs: BakedInValidators})
+var validate = New(Config{TagName: "validate"})
 
 func AssertError(t *testing.T, errs ValidationErrors, key, field, expectedTag string) {
 
@@ -1254,8 +1254,7 @@ func TestExistsValidation(t *testing.T) {
 func TestSQLValue2Validation(t *testing.T) {
 
 	config := Config{
-		TagName:         "validate",
-		ValidationFuncs: BakedInValidators,
+		TagName: "validate",
 	}
 
 	validate := New(config)
@@ -1311,13 +1310,16 @@ func TestSQLValue2Validation(t *testing.T) {
 
 func TestSQLValueValidation(t *testing.T) {
 
-	customTypes := map[reflect.Type]CustomTypeFunc{}
-	customTypes[reflect.TypeOf((*driver.Valuer)(nil))] = ValidateValuerType
-	customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
-	customTypes[reflect.TypeOf(MadeUpCustomType{})] = ValidateCustomType
-	customTypes[reflect.TypeOf(1)] = OverrideIntTypeForSomeReason
+	// customTypes := map[reflect.Type]CustomTypeFunc{}
+	// customTypes[reflect.TypeOf((*driver.Valuer)(nil))] = ValidateValuerType
+	// customTypes[reflect.TypeOf(valuer{})] = ValidateValuerType
+	// customTypes[reflect.TypeOf(MadeUpCustomType{})] = ValidateCustomType
+	// customTypes[reflect.TypeOf(1)] = OverrideIntTypeForSomeReason
 
-	validate := New(Config{TagName: "validate", ValidationFuncs: BakedInValidators, CustomTypeFuncs: customTypes})
+	validate := New(Config{TagName: "validate"})
+	validate.RegisterCustomTypeFunc(ValidateValuerType, (*driver.Valuer)(nil), valuer{})
+	validate.RegisterCustomTypeFunc(ValidateCustomType, MadeUpCustomType{})
+	validate.RegisterCustomTypeFunc(OverrideIntTypeForSomeReason, 1)
 
 	val := valuer{
 		Name: "",
@@ -3872,8 +3874,7 @@ func TestAddFunctions(t *testing.T) {
 	}
 
 	config := Config{
-		TagName:         "validateme",
-		ValidationFuncs: BakedInValidators,
+		TagName: "validateme",
 	}
 
 	validate := New(config)
@@ -3896,8 +3897,7 @@ func TestAddFunctions(t *testing.T) {
 func TestChangeTag(t *testing.T) {
 
 	config := Config{
-		TagName:         "val",
-		ValidationFuncs: BakedInValidators,
+		TagName: "val",
 	}
 	validate := New(config)
 


### PR DESCRIPTION
#### Additions
* Add alias logic. now can add an alias to validations using function RegisterAliasValidation. i.e. "iscolor" is alias for "hexcolor|rgb|rgba|hsl|hsla"

#### Changes
* dereference BakedInValidators, no need to pass in anymore, should use registration function to add more.
* add tag validation to ensure it does not overwrite core tags necessary to library operation and invalid characters.
* core changes of how and where caching is implemented.